### PR TITLE
Add Date Overrides

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,4 +2,5 @@ export ZULIP_LUNCHBOT_IN_PRODUCTION=True# Anything besides True for False
 export ZULIP_LUNCHBOT_EMAIL=lunchbot-staging-bot@recurse.zulipchat.com
 export ZULIP_LUNCHBOT_KEY=this-is-not-the-key
 export ZULIP_LUNCHBOT_STREAM=lunchbot-staging
+# export ZULIP_LUNCHBOT_DATE_OVERRIDES='-2017-07-03,-2017-07-04,+2017-07-07'
 # export HOME="" # Zulip requires HOME to be set to something. An empty string will work.

--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,10 @@ Join the 'lunchbot' stream to opt-in.
 On days when RC is open Lunchbot will privately message you after 11am to verify you want to be part of a lunch group.
 Around noon Lunchbot posts the lunch groups for that day in the 'lunchbot' stream.
 
+### Date overrides
+
+Sometimes lunchbot needs to run on non standard dates. To handle this you can set `ENV['ZULIP_LUNCHBOT_DATE_OVERRIDES']` to a comma separated list of dates prefixed by "+" or "-" in the format "2017-07-03". See `.env.sample` for examples.
+
 ## Local setup
 
 Add the expected variables to ENV. An easy way to do this is to `cp .env.sample .env` and edit `.env` to have the correct values. Then you can `source .env` before running `python bot.py`.


### PR DESCRIPTION
This moves the logic of when lunchbot runs from cron or an external scheduler into lunchbot. It also allows lunchbot to run on non-standard dates by setting `ZULIP_LUNCHBOT_DATE_OVERRIDES` in env.